### PR TITLE
New algorithm for building chains, and new extract sentences mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.class
 *.log
+*.gz
 
 log*
 access*

--- a/Readme.md
+++ b/Readme.md
@@ -45,11 +45,14 @@ aşamalardan oluşmaktadır:
 ###### 
 > **Cümle Seçimi İşlemleri:**
 
->- Sezgisel Algoritma 1
+>- <b>Sezgisel Algoritma 1</b>   
 Bu algoritma her zincirdeki ilk kelimenin yani zinciri başlatan kelimenin anahtar kelime olarak alınmasına dayanmaktadır. Bu anahtar kelimenin geçtiği ilk cümle tespit edilerek seçilmiştir.
->- Sezgisel Algoritma 2
-Bu algoritma her zincirdeki kelimelerin frekansının hesaplanmasına dayanmaktadır. Öncelikle tüm kelimelerin frekansı hesaplanır ve zincirdeki kelimelerin frekans ortalaması bulunur. Ortalama frekansın üstündeki kelimeler işleme alınır. Bu kelimelerin ortak olarak geçtikleri bir cümle mevcut ise bu cümle seçilir, eğer hiçbir kelimenin kesiştiği bir cümle yoksa, en yüksek frekanslı cümlenin geçtiği cümle alınır.
->- Sezgisel Algoritma 3
+>- <b>Sezgisel Algoritma 2</b>    
+İlk önce kaç tane güçlü zincir olduğuna bakılır. 
+Sadece bir tane güçlü zincir varsa, bu zincirdeki tüm kelimelerin aynı olup olmadığına bakılır.Eğer aynıysa, zincirdeki ilk iki kelimenin ait olduğu cümle alınır. Eğer aynı değilse, zincirdeki farklı kelimeler seçilip, onların ait olduğu cümleler alınır.
+Birden fazla güçlü zincir varsa, tüm bu zincirler bir döngü içerisine alınır, amacımız her zincir için, o konuyu temsil eden bir cümle seçmek. Bunun için yine zincirde farklı kelimeler var mı diye bakıyoruz, eğer yoksa, zincirdeki ilk iki kelimenin ait olduğu cümle alınır.
+Zincirde farkli kelimeler mevcutsa, öncelikle tüm kelimelerin frekansı hesaplanır ve zincirdeki kelimelerin frekans ortalaması bulunur. Ortalama frekansın üstündeki kelimeler işleme alınır. Bu kelimelerin ortak olarak geçtikleri bir cümle mevcut ise bu cümle seçilir, eğer hiçbir kelimenin kesiştiği bir cümle yoksa, en yüksek frekanslı cümlenin geçtiği cümle alınır.
+>- <b>Sezgisel Algoritma 3</b>    
 Bu algoritma her zincirin yoğunlaştığı paragrafı bulmaya ve bu paragrafta zincirdeki
 kelimeleri içeren cümle frekansına dayanmaktadır. Eğer tüm kelimeler aynı paragraftaysa doğrudan bu paragraftaki cümlelerin analizi yapılır. Eğer zincirdeki kelimeler farklı paragraflardaysa öncelikle paragrafların frekansları alınır. En yüksek frekanslı paragraf seçilir ve bu paragraftaki cümlelerin analizi yapılır. Cümle analizi, öncelikle zincirdeki kelimelerin hangi cümlelerde geçtiği bilindiği için bu kelimeler paragraflara göre ayıklanır ve her paragraf içinde bu kelimelerin ait oldukları cümlelerin frekansı alınır. En yüksek frekanslı cümleyi o zincir için seçilmektedir.
 
@@ -100,7 +103,7 @@ Bu arada karşılaşmayı Gençlik ve Spor Bakanı Suat Kılıç, Türkiye Voley
 Yıldız Kızlar Dünya Şampiyonası FIVB'nin düzenlediği ve 18 yaşının altındaki voleybolcuların katılabildiği bir şampiyonadır.  İlk şampiyona 1989 yılında Brezilya'nın Curitiba kentinde yapılmıştır. Her iki yılda bir düzenlenen şampiyonaya kıta elemelerini geçen ülke takımları katılabilmektedir.
 
 > **Özet:**
-[Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu., Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti., Yıldız Milli Takım, TVF Başkent Salonu'nda yapılan final maçında baştan sona üstün bir performans sergileyerek, Dünyanın en iyi takımları arasında yer alan Çin'e adeta göz açtırmadı.] 
+  Yıldız Kızlarımız Dünya Şampiyonu Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu. Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti. Yıldız Milli Takım, TVF Başkent Salonu'nda yapılan final maçında baştan sona üstün bir performans sergileyerek, Dünyanın en iyi takımları arasında yer alan Çin'e adeta göz açtırmadı. Tüm oyuncuların iyi oynadığı Türk Milli Takımı'nda Kübra Akman performansıyla göz doldururken, Çin Milli Takımı'nın solak smaçörü Peiyi Liu, Yıldız kızları zorlayan en önemli oyuncu oldu. 
 
 > **Kelime Zincirleri**
 >- "P1 S2" kelimenin 1. paragrafdaki 2. cümlede  geçtiğini belirtir
@@ -155,7 +158,7 @@ Yıldız Kızlar Dünya Şampiyonası FIVB'nin düzenlediği ve 18 yaşının al
 >- Kelime zinciri kriter değeri: 3.8724132730465493
 
 > **JSON API RESPOND:**
->- {<b>"result"</b>:"[Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu., Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti., Yıldız Milli Takım, TVF Başkent Salonu'nda yapılan final maçında baştan sona üstün bir performans sergileyerek, Dünyanın en iyi takımları arasında yer alan Çin'e adeta göz açtırmadı.] "
+>- {<b>"result"</b>:"[Yıldız Kızlarımız Dünya Şampiyonu Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu., Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti., Yıldız Milli Takım, TVF Başkent Salonu'nda yapılan final maçında baştan sona üstün bir performans sergileyerek, Dünyanın en iyi takımları arasında yer alan Çin'e adeta göz açtırmadı., Tüm oyuncuların iyi oynadığı Türk Milli Takımı'nda Kübra Akman performansıyla göz doldururken, Çin Milli Takımı'nın solak smaçörü Peiyi Liu, Yıldız kızları zorlayan en önemli oyuncu oldu.] "
 }
 
 ----------

--- a/build.sbt
+++ b/build.sbt
@@ -29,10 +29,10 @@ lazy val versions = new {
   val swagger = "0.5.0"
   val mongo = "2.1.0"
   val config = "1.3.2"
-  val zemberekCore = "0.13.0"
-  val zemberekTokenization = "0.13.0"
-  val zemberekMorphology = "0.13.0"
-  val zemberekNormalization = "0.13.0"
+  val zemberekCore = "0.16.0"
+  val zemberekTokenization = "0.16.0"
+  val zemberekMorphology = "0.16.0"
+  val zemberekNormalization = "0.16.0"
 
 }
 

--- a/src/main/scala/com/summarizer/services/ExtractSentenceService.scala
+++ b/src/main/scala/com/summarizer/services/ExtractSentenceService.scala
@@ -12,9 +12,9 @@ trait ExtractSentenceService extends Logging {
 
   def heuristic1(chains: Seq[Chain], sentences: Seq[String]): Seq[String]
 
-  def getFrequencyOfWords(words: Seq[String]): Map[String,Int]
+  def getFrequencyOfWords(words: Seq[String]): Map[String, Int]
 
-  def heuristic2(chains: Seq[Chain], sentences: Seq[String]): Seq[String]
+  def heuristic2(chains: Seq[Chain], paragraphsAndSentences: Map[Int, Seq[String]]): Seq[String]
 
 }
 
@@ -35,12 +35,12 @@ class DefaultExtractSentenceService extends ExtractSentenceService with Logging 
     chains.foreach { chain =>
       val lexicals = chain.members.map(_._1)
       val sentenceNo = lexicals.head.getSentenceNo()
-      if(!sentencesIndexNo.contains(sentenceNo)) {
+      if (!sentencesIndexNo.contains(sentenceNo)) {
         sentencesIndexNo = sentencesIndexNo :+ sentenceNo
       } else {
         lexicals.foreach { lexical =>
           val sentenceNo = lexical.getSentenceNo()
-          if(!sentencesIndexNo.contains(sentenceNo)) {
+          if (!sentencesIndexNo.contains(sentenceNo)) {
             sentencesIndexNo = sentencesIndexNo :+ sentenceNo
             break
           }
@@ -59,48 +59,92 @@ class DefaultExtractSentenceService extends ExtractSentenceService with Logging 
  * representative words, have a frequency in the chain noless than the
  * average word frequency in the chain.
  *
- * her zincirde kelimelerin frekansını belirle ortalama üstündeki kelimeleri
- * al -> temsilci kelimeler bu kelimeleri içeren ilk cümleyi al
+ * first check the chains length ,
+ * if we have only one chain then check how many unique words includes the chain, if all lexicals of chain are same,
+ * then get first two lexicals sentence no and fetch them
+ * else get the unique words and fetch sentences with their sentence no
+ *
+ * if we have more than one chain:
+ * go to for loop
+ * check if the chain has same lexicals only, then get one sentence from that chain, which is not selected yet
+ * if chain has different lexicals then get the frequency of words, use lexicals above frequency for fetching sentences
  *
  */
 
-  def getFrequencyOfWords(words: Seq[String]): Map[String,Int] = {
+  def getFrequencyOfWords(words: Seq[String]): Map[String, Int] = {
     val frequency = words.groupBy(identity).mapValues(_.size)
     frequency
   }
 
-  def heuristic2(chains: Seq[Chain], sentences: Seq[String]): Seq[String] = {
+  def heuristic2(chains: Seq[Chain], paragraphsAndSentences: Map[Int, Seq[String]]): Seq[String] = {
     info("Extract Sentence Service heuristic algorithm 2")
-    var selectedSentences = Map.empty[Int,String]
+    var selectedSentences = Map.empty[(Int, Int), String]
     var representativeWords = Set.empty[String]
-    for(chain <- chains) {
+
+    if (chains.length == 1) {
+      val chain = chains.head
       val words = chain.getWordsOfChain
-      val frequencyOfWords = getFrequencyOfWords(words)
       val uniqueWords = words.distinct
-      val meanOfFrequency =  words.size.toDouble / uniqueWords.size.toDouble
-      // all words are same
-      if(uniqueWords.size == 1) {
+      if (uniqueWords.size == 1) {
         val lexicals = chain.members.map(_._1)
-        val sentenceNo = lexicals.head.getSentenceNo()
-        val sentence = sentences(sentenceNo)
-        selectedSentences += (sentenceNo -> sentence)
-        representativeWords +: lexicals.head.getWord()
-      }
-      else {
-        val wordsAboveMean = frequencyOfWords.filter((word) => word._2.toDouble >= meanOfFrequency).keySet
-        val lexicals = chain.members.map(_._1).filter(lexical => wordsAboveMean.contains(lexical.getWord()))
-        lexicals.foreach { lexical =>
-          if(!representativeWords.contains(lexical.getWord())) {
-            val sentenceNo = lexical.getSentenceNo()
-            val sentence = sentences(sentenceNo)
-            selectedSentences += (sentenceNo -> sentence)
+        val values = lexicals.map { lexical =>
+          (lexical.getParagraphNo(),lexical.getSentenceNo())
+        }.distinct
+
+        val (firstSelectedParagraphNo,firstSelectedSentenceNo) = values.head
+        val sentences =  paragraphsAndSentences(firstSelectedParagraphNo)
+        selectedSentences += ((firstSelectedParagraphNo,firstSelectedSentenceNo) -> sentences(firstSelectedSentenceNo))
+        if (values.size > 1) {
+          val (secondSelectedParagraphNo,secondSelectedSentenceNo) = values(1)
+          val sentences =  paragraphsAndSentences(secondSelectedParagraphNo)
+          selectedSentences += ((secondSelectedParagraphNo,secondSelectedSentenceNo) -> sentences(secondSelectedParagraphNo))
+        }
+      } else {
+        uniqueWords.foreach { word =>
+          val lexicals = chain.members.map(_._1).filter(_.getWord() == word)
+          var sentenceNotAdded = true
+          for (lexical <- lexicals; if sentenceNotAdded) {
+            val (paragraphNo,sentenceNo) = (lexical.getParagraphNo(), lexical.getSentenceNo())
             representativeWords += lexical.getWord()
+            if (selectedSentences.get((paragraphNo, sentenceNo)).isEmpty) {
+              val sentences =  paragraphsAndSentences(paragraphNo)
+              selectedSentences += ((paragraphNo,sentenceNo) -> sentences(sentenceNo))
+              sentenceNotAdded = false
+            }
           }
         }
+      }
 
+    } else {
+      for (chain <- chains) {
+        val words = chain.getWordsOfChain
+        val uniqueWords = words.distinct
+        if (uniqueWords.size == 1) {
+          val lexical = chain.members.map(_._1).head
+          val (paragraphNo, sentenceNo) = (lexical.getParagraphNo(), lexical.getSentenceNo())
+          val sentences = paragraphsAndSentences(paragraphNo)
+          if (selectedSentences.get((paragraphNo, sentenceNo)).isEmpty) {
+            selectedSentences += ((paragraphNo, sentenceNo) -> sentences(sentenceNo))
+          }
+        } else {
+          val frequencyOfWords = getFrequencyOfWords(words)
+          val meanOfFrequency = words.size.toDouble / uniqueWords.size.toDouble
+          val wordsAboveMean = frequencyOfWords.filter((word) => word._2.toDouble >= meanOfFrequency).keySet
+          val lexicals = chain.members.map(_._1).filter(lexical => wordsAboveMean.contains(lexical.getWord()))
+          var sentenceNotAdded = true
+          for (lexical <- lexicals; if sentenceNotAdded) {
+            val (paragraphNo, sentenceNo) = (lexical.getParagraphNo(), lexical.getSentenceNo())
+            representativeWords += lexical.getWord()
+            if (selectedSentences.get((paragraphNo, sentenceNo)).isEmpty) {
+              val sentences = paragraphsAndSentences(paragraphNo)
+              selectedSentences += ((paragraphNo, sentenceNo) -> sentences(sentenceNo))
+              sentenceNotAdded = false
+            }
+          }
+        }
       }
     }
-    val sortedSelectedSentences = ListMap(selectedSentences.toSeq.sortBy(_._1):_*)
+    val sortedSelectedSentences = ListMap(selectedSentences.toSeq.sortBy(_._1): _*)
     val result = sortedSelectedSentences.values.toSeq
     result
   }

--- a/src/main/scala/com/summarizer/services/LexicalChainService.scala
+++ b/src/main/scala/com/summarizer/services/LexicalChainService.scala
@@ -27,9 +27,9 @@ class DefaultLexicalChainService extends LexicalChainService with Logging {
 
   def chainAnalyse(chains: Seq[Chain]) : Seq[Chain] = {
     info("Lexical Chain Service analyze chains")
-    val uniqueChains = collection.mutable.Map.empty[Seq[String], Chain]
+    val uniqueChains = collection.mutable.Map.empty[String, Chain]
     chains.foreach { chain =>
-      uniqueChains +=  (chain.getWordsOfChain -> chain)
+      uniqueChains +=  (chain.getWordsOfChain.toString() -> chain)
     }
 
     uniqueChains.values.toSeq

--- a/src/main/scala/com/summarizer/services/NounService.scala
+++ b/src/main/scala/com/summarizer/services/NounService.scala
@@ -24,14 +24,13 @@ trait NounService {
 class DefaultNounService @Inject() (sentenceService: SentenceService,
                                     paragraphService: ParagraphService) extends NounService with Logging {
 
-  val turkishMorphology = TurkishParserModule.getMorphology
+  private val turkishMorphology = TurkishParserModule.getMorphology
 
   override def getAnalyses(text: String): Seq[SentenceAnalysis] = {
     val paragraphs = paragraphService.getParagraphs(text)
     val sentences = paragraphs.flatMap(paragraph => sentenceService.getSentences(paragraph))
     val analyses : Seq[SentenceAnalysis] = sentences.map { sentence =>
-      val analysis = turkishMorphology.analyzeSentence(sentence)
-      turkishMorphology.disambiguate(sentence, analysis)
+      turkishMorphology.analyzeAndDisambiguate(sentence)
     }
     analyses
   }
@@ -40,7 +39,7 @@ class DefaultNounService @Inject() (sentenceService: SentenceService,
     var nouns : Seq[String] = Seq.empty[String]
     for(word : SingleAnalysis <- analysis.bestAnalysis().asScala) {
       if(word.formatLong().contains("Noun")) {
-        nouns = nouns :+ word.getStem()
+        nouns = nouns :+ word.getStem
       }
     }
     nouns
@@ -55,9 +54,8 @@ class DefaultNounService @Inject() (sentenceService: SentenceService,
 
   override def getNounsForSummary(text: String): Seq[String] = {
     info("Noun Service get nouns for summary")
-    val wordAnalysis = turkishMorphology.analyzeSentence(text)
-    val analysis = turkishMorphology.disambiguate(text, wordAnalysis)
-    val nouns = handleAnalyses(analysis)
+    val wordAnalysis = turkishMorphology.analyzeAndDisambiguate(text)
+    val nouns = handleAnalyses(wordAnalysis)
     nouns
   }
 }

--- a/src/main/scala/com/summarizer/services/SummaryService.scala
+++ b/src/main/scala/com/summarizer/services/SummaryService.scala
@@ -34,9 +34,11 @@ class DefaultSummaryService @Inject()(summaryRepository: SummaryRepository,
         val chainsWithStrengths = chainScoresService.calculateChainStrengths(chainsWithScores)
         val strongChains = chainScoresService.getStrongChains(chainsWithStrengths)
         val extractedSentences = extractSentenceService.heuristic2(strongChains, paragraphsAndSentences)
+        val summaryOfText = extractedSentences.mkString(" ")
         val summary = new Summary(contextOfText = contextOfText,
-          summaryOfText = Some(extractedSentences.mkString(" ")),
+          summaryOfText = Some(summaryOfText),
           wordChain = Some(strongChains.flatMap(_.getChainInformation).mkString))
+        info(s"Summary = $summaryOfText")
         Future(Right(summary))
       }
     }

--- a/src/main/scala/com/summarizer/services/SummaryService.scala
+++ b/src/main/scala/com/summarizer/services/SummaryService.scala
@@ -38,7 +38,8 @@ class DefaultSummaryService @Inject()(summaryRepository: SummaryRepository,
         val summary = new Summary(contextOfText = contextOfText,
           summaryOfText = Some(summaryOfText),
           wordChain = Some(strongChains.flatMap(_.getChainInformation).mkString))
-        info(s"Summary = $summaryOfText")
+        info(s"contextOfText = $contextOfText")
+        info(s"summaryOfText = $summaryOfText")
         Future(Right(summary))
       }
     }

--- a/src/test/resources/text/1.txt
+++ b/src/test/resources/text/1.txt
@@ -1,4 +1,4 @@
-﻿Yıldız Kızlarımız Dünya Şampiyonu
+﻿ Yıldız Kızlarımız Dünya Şampiyonu
 
 Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu. Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti.
 

--- a/src/test/resources/text/summary1.txt
+++ b/src/test/resources/text/summary1.txt
@@ -1,3 +1,1 @@
-﻿Yıldız Kızlarımız Dünya Şampiyonu
-
-Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu.Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti.
+﻿ Yıldız Kızlarımız Dünya Şampiyonu Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu. Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti. Yıldız Milli Takım, TVF Başkent Salonu'nda yapılan final maçında baştan sona üstün bir performans sergileyerek, Dünyanın en iyi takımları arasında yer alan Çin'e adeta göz açtırmadı. Tüm oyuncuların iyi oynadığı Türk Milli Takımı'nda Kübra Akman performansıyla göz doldururken, Çin Milli Takımı'nın solak smaçörü Peiyi Liu, Yıldız kızları zorlayan en önemli oyuncu oldu.

--- a/src/test/scala/com/summarizer/services/LexicalChainServiceTest.scala
+++ b/src/test/scala/com/summarizer/services/LexicalChainServiceTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.FunSpec
 class LexicalChainServiceTest extends FunSpec {
 
   val lexicalChainService = new DefaultLexicalChainService
-  describe("Get verbs") {
+  describe("build chains") {
     it("should build chains") {
 
       val lexical1 = new Lexical("araba", 1, 1)

--- a/src/test/scala/com/summarizer/services/NounServiceTest.scala
+++ b/src/test/scala/com/summarizer/services/NounServiceTest.scala
@@ -11,7 +11,7 @@ class NounServiceTest extends FunSpec with CommonServices {
     it("should return all nouns") {
       val text = paragraph1.concat(paragraph2)
       val nouns = nounService.getNouns(text)
-      val result = Seq("dünya", "yıldız", "kız", "voleybol", "şampiyona", "yıldız", "mil", "takım", "final", "maç", "çin", "şampiyon", "türkiye", "voleybol", "tarih", "ilk", "dünya", "şampiyon", "el", "ilk", "şampiyona", "yıl", "brezilya", "curitiba", "kent", "yıl", "düz", "şampiyona", "kıta", "ele", "ülke", "takım")
+      val result = Seq("dünya", "yıldız", "kız", "voleybol", "şampiyona", "yıldız", "takım", "final", "maç", "çin", "şampiyon", "türkiye", "voleybol", "tarih", "dünya", "şampiyon", "el", "şampiyona", "yıl", "brezilya", "curitiba", "kent", "yıl", "şampiyona", "kıta", "ele", "ülke", "takım")
 
       assert(nouns === result)
     }

--- a/src/test/scala/com/summarizer/services/PreProcessServiceTest.scala
+++ b/src/test/scala/com/summarizer/services/PreProcessServiceTest.scala
@@ -17,9 +17,12 @@ class PreProcessServiceTest extends FunSpec with CommonServices {
     }
 
     it("should generate all lexicals") {
-      val allLexicals = preProcessService.getAllLexicals(paragraph1)
-      val expectedLexicals = Seq("dünya", "yıldız", "kız", "voleybol", "şampiyona", "yıldız", "mil", "takım", "final", "maç", "çin", "şampiyon", "türkiye", "voleybol", "tarih", "ilk", "dünya", "şampiyon", "el", "ilk", "şampiyona", "yıl", "brezilya", "curitiba", "kent", "yıl", "düz", "şampiyona", "kıta", "ele", "ülke", "takım")
-      allLexicals.size shouldBe 19
+      val sentences = Seq("Dünya Yıldız Kızlar Voleybol Şampiyonası'nda Yıldız Milli Takım, final maçında Çin'i 3-0 yenerek şampiyon oldu.",
+                          "Türkiye, böylece voleybol tarihinin ilk Dünya şampiyonluğunu elde etti.")
+      val paragraphsAndSentences = Map( 0 -> sentences)
+      val allLexicals = preProcessService.getAllLexicals(paragraphsAndSentences)
+      val expectedLexicals = Seq("dünya", "yıldız", "kız", "voleybol", "şampiyona", "yıldız", "takım", "final", "maç", "çin", "şampiyon", "türkiye", "voleybol", "tarih", "dünya", "şampiyon", "el", "şampiyona", "yıl", "brezilya", "curitiba", "kent", "yıl", "şampiyona", "kıta", "ele", "ülke", "takım")
+      allLexicals.size shouldBe 17
       allLexicals.zipWithIndex.foreach { case (lexical, lexicalIndexNo) =>
         lexical.getWord() shouldBe expectedLexicals(lexicalIndexNo)
       }

--- a/src/test/scala/com/summarizer/services/VerbServiceTest.scala
+++ b/src/test/scala/com/summarizer/services/VerbServiceTest.scala
@@ -10,8 +10,8 @@ class VerbServiceTest extends FunSpec with CommonServices {
   describe("Get verbs") {
     it("should return all verbs") {
       val text = paragraph1.concat(paragraph2)
-      val verbs = verbService.getVerbs(text).toSeq
-      val result = Seq("yemek", "olmak", "etmek", "yapmak", "düzmek", "elemek", "geçmek", "katılmak")
+      val verbs = verbService.getVerbs(text)
+      val result = Seq("yenmek", "olmak", "etmek", "yapmak", "düzenlemek", "elemek", "katılmak")
 
       assert(verbs === result)
     }


### PR DESCRIPTION
I had problems with my current implementation when I try to run it on small server setups like :
` H3 Quad-core Cortex-A7 H.265/HEVC 4K`
`2GB DDR3 (shared with GPU)`

So I decided to change the algorithm for building chains , we had some discussions with my work mate (@niwic) and got a final algorithm which is very fast. 

**NEW ALGORITHM FOR BUILDING CHAINS**
Basically new algorithm, uses `related_word` as a key for Map, and all the lexical which are related to that `related_word` are inserted to the Map.
for example your lexicals with their relations:
`A - synonym - B`
`C - antonym - B`
`K - hypernym - B`
`X - related_with - C`
`M - hyponym - C`

it will create two chains:
`Map("B" -> Chain)`
`Map("C" -> Chain)`

For doing that , I had to check all relations excel and remove duplicates , which took almost over 3 weeks. Hopefully, now it shouldn't have any duplicate relations.

**NEW MECHANISM FOR EXTRACT SENTENCES**
Previously, it wasn't handling corner cases like if only one strong chain with same lexicals etc, now it covers more cases, so it returns better summarizes. 
**Case 1:** If there is only one strong chain, check if all lexicals are same or not, if same take first two sentences, else get unique words and fetch related sentences
**Case 2:** Multiple chains, create a loop, go through all chains, check if chain has only same lexicals, then try to get one sentence from that chain which is not selected yet,
otherwise get the frequency of words, use lexicals above frequency for fetching sentences

**ZEMBEREK VERSION UPDATED**
Because they released two more new versions, I updated to latest for using new functions. I noticed that getting nouns is improved.