### PR TITLE
Remove chain info

### DIFF
--- a/src/main/scala/com/summarizer/services/SummaryService.scala
+++ b/src/main/scala/com/summarizer/services/SummaryService.scala
@@ -40,7 +40,7 @@ class DefaultSummaryService @Inject()(preProcessService: PreProcessService,
           val summaryOfText = extractedSentences.mkString(" ")
           val summary = Summary(contextOfText = contextOfText,
             summaryOfText = Some(summaryOfText),
-            wordChain = Some(strongChains.flatMap(_.getChainInformation).mkString))
+            wordChain = None)
           info(s"contextOfText = $contextOfText")
           info(s"summaryOfText = $summaryOfText")
           val end = System.currentTimeMillis()


### PR DESCRIPTION
Chain info was introduced to save it in database. But currently it is not used anywhere. Unnecessary data traffic. Plus converting it to string causes some memory problem. It will be fixed later whenever database is available.